### PR TITLE
feat(install-pkgs): Add impacket-wmiexec

### DIFF
--- a/install-pkgs.sh
+++ b/install-pkgs.sh
@@ -15,6 +15,7 @@ geoip-database
 gnutls-bin
 heimdal-dev
 ike-scan
+impacket-wmiexec
 libgcrypt20-dev
 libglib2.0-dev
 libgnutls28-dev

--- a/install-pkgs.sh
+++ b/install-pkgs.sh
@@ -15,7 +15,7 @@ geoip-database
 gnutls-bin
 heimdal-dev
 ike-scan
-impacket-wmiexec
+python3-impacket
 libgcrypt20-dev
 libglib2.0-dev
 libgnutls28-dev


### PR DESCRIPTION
Fixes "win_cmd_exec: Failed to execute child process “impacket-wmiexec” (No such file or directory)" error.