### PR TITLE
Added 3128 port forwarded back over autossh for optional proxy behind…

### DIFF
--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -48,7 +48,7 @@ killasgroup=true
 
 [program:autossh]
 priority=5
-command=autossh -M 0 -N -T -i /var/lib/gvm/.ssh/key -o ExitOnForwardFailure=yes -o UserKnownHostsFile=/var/lib/gvm/.ssh/known_hosts -p %(ENV_MASTER_PORT)s -R /sockets/%(ENV_SCANNER_ID)s.sock:/var/run/ospd/ospd.sock gvm@%(ENV_MASTER_ADDRESS)s
+command=autossh -M 0 -N -T -i /var/lib/gvm/.ssh/key -o ExitOnForwardFailure=yes -o UserKnownHostsFile=/var/lib/gvm/.ssh/known_hosts -p %(ENV_MASTER_PORT)s -L 127.0.0.1:3128:127.0.0.1:3128 -R /sockets/%(ENV_SCANNER_ID)s.sock:/var/run/ospd/ospd.sock gvm@%(ENV_MASTER_ADDRESS)s
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s_err.log
 startsecs=10


### PR DESCRIPTION
Certain restricted environments have no internet connectivity and updating the image is problematic in those environments with rsync.

The OpenVAS image could use the existing SSH tunnel (forward a local port next to the unix socket) to access a Squid proxy running on the main GVM instance. Starting the proxy would be optional and in case it is not started, it wouldn't be possible to access it from the OpenVAS.

## Summary

Just adding local 3128 port forwarded to main GVM 3128 port in the ssh tunnel for optional rsync proxy.

### Checklist

- [ x ] [Update Documentation](https://github.com/Secure-Compliance-Solutions-LLC/gitbook) extra variables added for documentation.

### Fixed Bug/Issues solved:

Created issues: #16 in OpenVAS-Docker and #344 in GVM-Docker.
https://github.com/Secure-Compliance-Solutions-LLC/OpenVAS-Docker/issues/16
https://github.com/Secure-Compliance-Solutions-LLC/GVM-Docker/issues/344
